### PR TITLE
Plug-in neovim-fuzzy was added in init.vim

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -18,6 +18,7 @@ Plug 'numkil/ag.nvim' " Ag command from nvim
 Plug 'scrooloose/nerdtree' " File navigation with NERDTree
 Plug 'tikhomirov/vim-glsl' " syntax highlighting for GLSL
 Plug 'sakhnik/nvim-gdb', { 'do': ':!./install.sh \| UpdateRemotePlugins' } " Gdb, LLDB and PDB integration :)
+Plug 'cloudhead/neovim-fuzzy' " Fuzzy file finder. Requires install fzy (sudo apt install fzy)
 
 call plug#end()
 
@@ -92,8 +93,8 @@ nnoremap <C-h> :find %:t:r.h<CR>
 " Move to c++ source file
 nnoremap <C-s> :find %:t:r.cpp<CR>
 
-" Ctrl-P replacement (trailing space to make life easier)
-nnoremap <C-p> :find 
+" Ctrl-P replacement
+nnoremap <C-p> :FuzzyOpen<CR>
 
 " --- PLUGINS -----------------------------------------------------------------
 


### PR DESCRIPTION
The shortcut Crtl-P was replaced to use this file finder.

In order to use this plug-in fzy should be installed (sudo apt install fzy).

Now it is possible to work from the build directory and call :make :D